### PR TITLE
Fix docker repo name in semantic release config

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -16,8 +16,8 @@
       "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
     }],
     ["@codedependant/semantic-release-docker", {
-      "dockerImage": "my-python-app",
-      "dockerProject": "EpicMandM",
+      "dockerImage": "semantic-release-demo",
+      "dockerProject": "epicmandm",
       "dockerTags": ["{{version}}", "latest"]
     }]
   ]


### PR DESCRIPTION
## Summary
- use lowercase repo for docker image names in `.releaserc`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6853c4a6b64883308d1e805f6f3a8a00